### PR TITLE
Add User-agent to avoid server errors.

### DIFF
--- a/directdl.py
+++ b/directdl.py
@@ -69,6 +69,9 @@ downloaded = os.listdir(TARGETDIR)
 missingfiles = list(set(allfiles).difference(set(downloaded)))
 missingfiles.sort()
 s = requests.Session()
+s.headers = {
+   'User-Agent': 'Mozilla/5.0'
+}
 
 while len(missingfiles) > 0:
    #candidate = random.sample(missingfiles,1)[0]


### PR DESCRIPTION
Adding a User-agent to requests avoids server errors (probably due to throttling).